### PR TITLE
Version 0.8.1, Fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ These can be found in the `snippets` folder of the repository.
 
 ## Changelog
 
+**0.8.1**
+
+- fixed titlebar drag issue #8
+
 **0.8.0**
 
 - remove workaround from earlier to re-fix search area #12

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Sodalite",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "minAppVersion": "1.0.0",
     "author": "tomzorz",
     "authorUrl": "https://twitter.com/tomzorz_"

--- a/obsidian.css
+++ b/obsidian.css
@@ -338,6 +338,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 /* title bar */
 
 .titlebar {
+    -webkit-app-region: drag;
 }
 
 .titlebar .titlebar-text {

--- a/theme.css
+++ b/theme.css
@@ -444,6 +444,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 /* title bar */
 
 .titlebar {
+    -webkit-app-region: drag;
 }
 
 .titlebar .titlebar-text, 


### PR DESCRIPTION
- This attribute should be applied to the titlebar of a frameless window, because frameless windows no longer drag by default.
- Value was applied to both `obsidian.css` and `theme.css`
- Reference: https://github.com/electron/electron/blob/ee108903a087e64a3dd03bd5d420e06453285b8b/docs/tutorial/window-customization.md?plain=1#L216-L222
- According to semver, this patch is backwards compatible, so `0.8.1` is appropriate
- Updated README.md changelog to reflect the change