### PR TITLE
Force titlebar drag to apply for #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ These can be found in the `snippets` folder of the repository.
 
 ## Changelog
 
+**0.8.2**
+- fixed the previous patch by forcing it to apply
+
 **0.8.1**
 
 - fixed titlebar drag issue #8

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Sodalite",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "minAppVersion": "1.0.0",
     "author": "tomzorz",
     "authorUrl": "https://twitter.com/tomzorz_"

--- a/obsidian.css
+++ b/obsidian.css
@@ -338,7 +338,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 /* title bar */
 
 .titlebar {
-    -webkit-app-region: drag;
+    -webkit-app-region: drag !important;
 }
 
 .titlebar .titlebar-text {
@@ -356,7 +356,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 .titlebar .titlebar-text::after {
     z-index: 5;
     opacity: 0.7;
-    content: " - https://tmz.io/sodalite v0.6.5";
+    content: " - https://tmz.io/sodalite v0.8.2";
 }
 
 /* status bar */

--- a/theme.css
+++ b/theme.css
@@ -444,7 +444,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 /* title bar */
 
 .titlebar {
-    -webkit-app-region: drag;
+    -webkit-app-region: drag !important;
 }
 
 .titlebar .titlebar-text, 
@@ -466,7 +466,7 @@ body:not(.plugin-sliding-panes):not(.is-mobile) .workspace-leaf-content[data-typ
 .titlebar .titlebar-text::after {
     z-index: 5;
     opacity: 0.7;
-    content: " - https://tmz.io/sodalite v0.8.0";
+    content: " - https://tmz.io/sodalite v0.8.2";
 }
 
 /* status bar */


### PR DESCRIPTION
- Force drag property to apply with `!important`
- Bumped to version 0.8.2
- Updated version value in titlebar to match